### PR TITLE
[Restate UI] Update to v0.0.70

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.69"
+version = "0.0.70"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
 publish = false
 edition = "2021"
-version = "0.0.69"
+version = "0.0.70"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v0.0.70
ui-v0.0.70.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.70/ui-v0.0.70.zip
sha256: dae47718fabaaf2230befa36aabac051ee9d804330a841e92bb1c5a5c083f84f