### PR TITLE
[Restate UI] Update to v0.0.93

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.92"
+version = "0.0.93"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
 publish = false
 edition = "2021"
-version = "0.0.92"
+version = "0.0.93"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v0.0.93
ui-v0.0.93.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.93/ui-v0.0.93.zip
sha256: 4a1cc9a00fddc85aecdef3a756179646ea7a1fadce89ad393f4417c982eeb5f6