### PR TITLE
[Restate UI] Update to v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
 publish = false
 edition = "2021"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v0.1.4
ui-v0.1.4.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.4/ui-v0.1.4.zip
sha256: 167b4f86a63e40742ea53a8857b06791a030a860c3f9ee0ee2c30b47047a17fb