### PR TITLE
[Restate UI] Update to v0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
 publish = false
 edition = "2021"
-version = "0.1.10"
+version = "0.1.11"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v0.1.11
ui-v0.1.11.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.11/ui-v0.1.11.zip
sha256: 616e9f6cdbf0618347d23b176daf3cb1a7b648d44ff91f8f1e3510e2332538dd