### PR TITLE
[Restate UI] Update to v0.1.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.55"
+version = "0.1.56"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper restate's web UI"
 publish = false
 edition = "2024"
-version = "0.1.55"
+version = "0.1.56"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v0.1.56
ui-v0.1.56.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.56/ui-v0.1.56.zip
sha256: 13b399e7e99a9daa2485a3075bfa1bd181aed4131f34138bdc757e6ac29e96e2