### PR TITLE
[Restate UI] Update to v0.1.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper restate's web UI"
 publish = false
 edition = "2024"
-version = "0.1.56"
+version = "0.1.57"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v0.1.57
ui-v0.1.57.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.57/ui-v0.1.57.zip
sha256: 61a6ecfa51892981d2dc13438d2d5af97aa216d252973f78381cea2ea016aa6b