### PR TITLE
[Restate UI] Update to v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.66"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper restate's web UI"
 publish = false
 edition = "2024"
-version = "0.1.66"
+version = "1.0.0"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v1.0.0
ui-v1.0.0.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.0/ui-v1.0.0.zip
sha256: 01490c14f3d5af5f5c01d2446f190364b3a873749b0ff9314b7ee08f55ce0e13