### PR TITLE
[Restate UI] Update to v1.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper restate's web UI"
 publish = false
 edition = "2024"
-version = "1.0.8"
+version = "1.0.9"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v1.0.9
ui-v1.0.9.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.9/ui-v1.0.9.zip
sha256: f99f60ae0dd43b76158f6e93b74a50ca0fe0aaef92968067693a4df253859e49