### PR TITLE
[Restate UI] Update to v1.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-web-ui"
 description = "Rust wrapper restate's web UI"
 publish = false
 edition = "2024"
-version = "1.0.11"
+version = "1.0.12"
 
 [dependencies]
 include_dir = "0.7.4"


### PR DESCRIPTION
### [UI] Updating UI assets to v1.0.12
ui-v1.0.12.zip published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.12/ui-v1.0.12.zip
sha256: cb819b1f05a5605e5a3bfa872aefcef1099e69e16395a6f9f1b2d23f427cc971